### PR TITLE
Hopefully fix governor issues.

### DIFF
--- a/drivers/cpufreq/cpufreq_abyssplug.c
+++ b/drivers/cpufreq/cpufreq_abyssplug.c
@@ -59,7 +59,7 @@ static int cpufreq_governor_dbs(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_abyssplug = {
-       .name                   = "Abyssplug",
+       .name                   = "abyssplug",
        .governor               = cpufreq_governor_dbs,
        .owner                  = THIS_MODULE,
 };

--- a/drivers/cpufreq/cpufreq_adaptive.c
+++ b/drivers/cpufreq/cpufreq_adaptive.c
@@ -65,7 +65,7 @@ static int cpufreq_governor_dbs(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_adaptive = {
-	.name                   = "Adaptive",
+	.name                   = "adaptive",
 	.governor               = cpufreq_governor_dbs,
 	.max_transition_latency = TRANSITION_LATENCY_LIMIT,
 	.owner                  = THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_badass.c
+++ b/drivers/cpufreq/cpufreq_badass.c
@@ -94,7 +94,7 @@ unsigned int event);
 static
 #endif
 struct cpufreq_governor cpufreq_gov_badass = {
-       .name = "Badass",
+       .name = "badass",
        .governor = cpufreq_governor_bds,
        .max_transition_latency = TRANSITION_LATENCY_LIMIT,
        .owner = THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_conservative.c
+++ b/drivers/cpufreq/cpufreq_conservative.c
@@ -594,7 +594,7 @@ static int cpufreq_governor_dbs(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_conservative = {
-	.name			= "Conservative",
+	.name			= "conservative",
 	.governor		= cpufreq_governor_dbs,
 	.max_transition_latency	= TRANSITION_LATENCY_LIMIT,
 	.owner			= THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_interactiveX.c
+++ b/drivers/cpufreq/cpufreq_interactiveX.c
@@ -93,7 +93,7 @@ static int cpufreq_governor_interactivex(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_interactivex = {
-	.name = "InteractiveX",
+	.name = "interactivex",
 	.governor = cpufreq_governor_interactivex,
 	.max_transition_latency = 10000000,
 	.owner = THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_lagfree.c
+++ b/drivers/cpufreq/cpufreq_lagfree.c
@@ -329,7 +329,7 @@ static struct attribute * dbs_attributes[] = {
 
 static struct attribute_group dbs_attr_group = {
 	.attrs = dbs_attributes,
-	.name = "Lagfree",
+	.name = "lagfree",
 };
 
 /************************** sysfs end ************************/
@@ -649,7 +649,7 @@ static int cpufreq_governor_dbs(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_lagfree = {
-	.name			= "Lagfree",
+	.name			= "lagfree",
 	.governor		= cpufreq_governor_dbs,
 	.max_transition_latency	= TRANSITION_LATENCY_LIMIT,
 	.owner			= THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_sakuractive.c
+++ b/drivers/cpufreq/cpufreq_sakuractive.c
@@ -60,7 +60,7 @@ static int cpufreq_governor_dbs(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_sakuractive = {
-       .name                   = "Sakuractive",
+       .name                   = "sakuractive",
        .governor               = cpufreq_governor_dbs,
        .owner                  = THIS_MODULE,
 };

--- a/drivers/cpufreq/cpufreq_savaged_zen.c
+++ b/drivers/cpufreq/cpufreq_savaged_zen.c
@@ -155,7 +155,7 @@ static int cpufreq_governor_savagedzen(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_savagedzen = {
-        .name = "SavagedZen",
+        .name = "savagedzen",
         .governor = cpufreq_governor_savagedzen,
         .max_transition_latency = 9000000,
         .owner = THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_savagedzen.c
+++ b/drivers/cpufreq/cpufreq_savagedzen.c
@@ -155,7 +155,7 @@ static int cpufreq_governor_savagedzen(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_savagedzen = {
-        .name = "SavagedZen",
+        .name = "savagedzen",
         .governor = cpufreq_governor_savagedzen,
         .max_transition_latency = 9000000,
         .owner = THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_scary.c
+++ b/drivers/cpufreq/cpufreq_scary.c
@@ -757,7 +757,7 @@ static int cpufreq_governor_dbs(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_scary = {
-	.name			= "Scary",
+	.name			= "scary",
 	.governor		= cpufreq_governor_dbs,
 	.max_transition_latency	= TRANSITION_LATENCY_LIMIT,
 	.owner			= THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_smartass.c
+++ b/drivers/cpufreq/cpufreq_smartass.c
@@ -153,7 +153,7 @@ static int cpufreq_governor_smartass(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_smartass = {
-	.name = "Smartass",
+	.name = "smartass",
 	.governor = cpufreq_governor_smartass,
 #if defined(CONFIG_ARCH_MSM_SCORPION)
 	.max_transition_latency = 8000000,

--- a/drivers/cpufreq/cpufreq_smartass2.c
+++ b/drivers/cpufreq/cpufreq_smartass2.c
@@ -165,7 +165,7 @@ static int cpufreq_governor_smartass(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_smartass2 = {
-	.name = "SmartassV2",
+	.name = "smartassV2",
 	.governor = cpufreq_governor_smartass,
 	.max_transition_latency = 9000000,
 	.owner = THIS_MODULE,

--- a/drivers/cpufreq/cpufreq_wheatley.c
+++ b/drivers/cpufreq/cpufreq_wheatley.c
@@ -68,7 +68,7 @@ static int cpufreq_governor_dbs(struct cpufreq_policy *policy,
 static
 #endif
 struct cpufreq_governor cpufreq_gov_wheatley = {
-    .name                   = "Wheatley",
+    .name                   = "wheatley",
     .governor               = cpufreq_governor_dbs,
     .max_transition_latency = TRANSITION_LATENCY_LIMIT,
     .owner                  = THIS_MODULE,


### PR DESCRIPTION
The issue has to be case sensitivity. Most governors had two different names, one capitalized and one lowercase. Can you make a test build first?
Because I noticed that the Conservative governor stored its config files to /sys/devices/system/cpu/cpufreq/**_c_**onservative, and apps must've been looking for /sys/devices/system/cpu/cpufreq/**_C_**onservative so they were crashing.
@bryan2894 thanks. If you want to consolidate it, be my guest. I don't want to download the kernel again. ×_×

And I don't know why, but there are two SavagedZen copies. cpufreq_savaged_zen.c and cpufreq_savagedzen.c
