### PR TITLE
I think UV'ing the screen to 500mAh is a bit much

### DIFF
--- a/arch/arm/mach-msm/board-msm8x60_celox.c
+++ b/arch/arm/mach-msm/board-msm8x60_celox.c
@@ -14142,7 +14142,7 @@ static int mipi_S6E8AA0_panel_power(int enable)
 }
 #endif
 
-int panel_uv = 500;
+int panel_uv = 250;
 module_param(panel_uv, int, 0664);
 
 #define LD9040_DEFAULT_VOLTAGE 3000000


### PR DESCRIPTION
Decreased default display undervolt to 250mAh which might solve the stripes a user was talking about.
